### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Diffusers StableDiffusion3.5-Large LoRA Training Cog Model
 
+[![Try a demo on Replicate](https://replicate.com/lucataco/stable-diffusion-3.5-large-lora-trainer/badge)](https://replicate.com/lucataco/stable-diffusion-3.5-large-lora-trainer)
+
 Cog implementation of the [Diffusers Dreambooth LoRA Trainer](https://github.com/huggingface/diffusers/blob/main/examples/dreambooth/README_sd3.md)
 
 ## How to use


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.